### PR TITLE
Use sequelize methods

### DIFF
--- a/client/app/sessions/sessions.js
+++ b/client/app/sessions/sessions.js
@@ -91,6 +91,7 @@ angular.module('dinnerDaddy.sessions', [])
       }); 
     };
     // change to user id not username, call it userId, same with session
+    // SHOULD BE A NUMBER
     var joinSession = function(username, sessionName) {
       return $http({
         method: 'POST',

--- a/client/app/sessions/sessions.js
+++ b/client/app/sessions/sessions.js
@@ -90,7 +90,7 @@ angular.module('dinnerDaddy.sessions', [])
         console.error(err);
       }); 
     };
-
+    // change to user id not username, call it userId, same with session
     var joinSession = function(username, sessionName) {
       return $http({
         method: 'POST',

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -66,7 +66,7 @@ module.exports = function ( app, express ) {
 
   /* SESSIONS_USERS */
   app.get('/api/sessions/users/:sessionId', sessionsController.getAllUsers);
-  app.get('/api/sessions/:sessionName', sessionsController.getSessionByName);
+  app.get('/api/sessions/:id', sessionsController.getSession);
   // app.get('/api/sessions/:session_id/:user_id', sessionsController.getOneUser);
   app.post('/api/sessions/users', sessionsController.addUser);
 

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -65,7 +65,7 @@ module.exports = function ( app, express ) {
   app.post('/api/votes', votesController.addVote );
 
   /* SESSIONS_USERS */
-  app.get('/api/sessions/users/:sessionName', sessionsController.getAllUsers);
+  app.get('/api/sessions/users/:sessionId', sessionsController.getAllUsers);
   app.get('/api/sessions/:sessionName', sessionsController.getSessionByName);
   // app.get('/api/sessions/:session_id/:user_id', sessionsController.getOneUser);
   app.post('/api/sessions/users', sessionsController.addUser);

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -5,7 +5,7 @@ var moviesController = require('../movies/moviesController.js');
 var prefsController = require('../prefs/prefsController.js');
 var sessionsController = require('../sessions/sessionsController.js');
 var votesController = require('../votes/votesController.js');
-var sessions_usersController = require('../sessions_users/sessions_usersController.js');
+// var sessions_usersController = require('../sessions_users/sessions_usersController.js');
 var passport = require('passport');
 var Strategy = require('passport-facebook').Strategy;
 
@@ -65,10 +65,10 @@ module.exports = function ( app, express ) {
   app.post('/api/votes', votesController.addVote );
 
   /* SESSIONS_USERS */
-  app.get('/api/sessions/users/:sessionName', sessions_usersController.getUsersInOneSession );
-  app.get('/api/sessions/:sessionName', sessionsController.getSessionByName );
-  app.get('/api/sessions/:session_id/:user_id', sessions_usersController.getSessionUserBySessionAndUser );
-  app.post('/api/sessions/users', sessions_usersController.addOneUser );
+  app.get('/api/sessions/users/:sessionName', sessionsController.getAllUsers);
+  app.get('/api/sessions/:sessionName', sessionsController.getSessionByName);
+  // app.get('/api/sessions/:session_id/:user_id', sessionsController.getOneUser);
+  app.post('/api/sessions/users', sessionsController.addUser);
 
   /* MATCHING */
   // This endpoint answers the question, 'For session <id>, do we currently have a match on movie <id>?'

--- a/server/sessions/sessions.js
+++ b/server/sessions/sessions.js
@@ -1,15 +1,18 @@
-var db = require( '../config/db' );
-var Sequelize = require( 'sequelize' );
+var db = require('../config/db');
+var Sequelize = require('sequelize');
+var User = require('../users/users');
 
-var Session = db.define( 'sessions', {
+var Session = db.define('sessions', {
   sessionName : Sequelize.STRING
-} );
+});
 
-Session.sync().then( function() {
-  console.log( "sessions table created" );
-} )
-.catch( function( err ) {
-  console.error( err );
-} );
+var UserSession = db.define('user_sessions', {});
+Session.belongsToMany(User, {through: UserSession});
+User.belongsToMany(Session, {through: UserSession});
+
+UserSession.sync();
+Session.sync();
+User.sync();
+
 
 module.exports = Session;

--- a/server/sessions/sessions.js
+++ b/server/sessions/sessions.js
@@ -5,7 +5,9 @@ var User = require('../users/users');
 var Session = db.define('sessions', {
   sessionName : Sequelize.STRING
 });
-
+// This is the join table connecting User and Session
+// We get a lot of Sequelize methods for free by using
+// belongsToMany (see http://docs.sequelizejs.com/en/latest/docs/associations/?highlight=belongsToMany)
 var UserSession = db.define('user_sessions', {});
 Session.belongsToMany(User, {through: UserSession});
 User.belongsToMany(Session, {through: UserSession});

--- a/server/sessions/sessionsController.js
+++ b/server/sessions/sessionsController.js
@@ -34,6 +34,7 @@ module.exports = {
   getAllUsers: function(req, res, next) {
     Session.find({where: {id: req.params.sessionId}})
     .then(function(session) {
+      // use Sequelize method provided by belongsToMany relationship
       return session.getUsers();
     })
     .then(function(users) {
@@ -63,6 +64,7 @@ module.exports = {
       .then(function(data) {
         var session = data.session;
         var user = data.user;
+        // use Sequelize method provided by belongsToMany relationship
         session.addUser(user);
         res.json(user);
       })

--- a/server/sessions/sessionsController.js
+++ b/server/sessions/sessionsController.js
@@ -1,5 +1,6 @@
 var helpers = require('../config/helpers');
 var Session = require('./sessions');
+var User = require('../users/users');
 
 module.exports = {
 
@@ -22,14 +23,53 @@ module.exports = {
   },
 
   getSessionByName: function(req, res, next) {
-    var sessionName = req.params.sessionName;
-
-    Session.findOne({where: {sessionName: sessionName}})
+    Session.findOne({where: {sessionName: req.query.sessionName}})
     .then(function(session) {
       res.json(session);
     }, function(err) {
       helpers.errorHandler(err, req, res, next);
     });
+  },
+
+  getAllUsers: function(req, res, next) {
+    Session.find({where: {id: req.params.sessionId}})
+    .then(function(session) {
+      return session.getUsers();
+    })
+    .then(function(users) {
+      res.json(users);
+    })
+    .catch(function(err) {
+      console.error(err);
+    });
+  },
+
+  // getOneUser: function(req, res, next) {
+  //   console.log('query', req.query);
+  // },
+
+  addUser: function(req, res, next) {
+    var userId = parseInt(req.body.userId);
+    var sessionId = parseInt(req.body.sessionId);
+    User.find({where: {id: userId}})
+    .then(function(user) {
+      Session.find({where: {id: sessionId}})
+      .then(function(session) {
+        return {
+          user: user,
+          session: session
+        };
+      })
+      .then(function(data) {
+        var session = data.session;
+        var user = data.user;
+        session.addUser(user);
+        res.json(user);
+      })
+    })
+    .catch(function(err) {
+      console.error(err);
+    })
   }
   
 };

--- a/server/sessions/sessionsController.js
+++ b/server/sessions/sessionsController.js
@@ -22,8 +22,8 @@ module.exports = {
     });
   },
 
-  getSessionByName: function(req, res, next) {
-    Session.findOne({where: {sessionName: req.query.sessionName}})
+  getSession: function(req, res, next) {
+    Session.findOne({where: {ide: req.params.id}})
     .then(function(session) {
       res.json(session);
     }, function(err) {

--- a/server/sessions/sessionsController.js
+++ b/server/sessions/sessionsController.js
@@ -23,7 +23,8 @@ module.exports = {
   },
 
   getSession: function(req, res, next) {
-    Session.findOne({where: {ide: req.params.id}})
+    var id = parseInt(req.params.id);
+    Session.findOne({where: {ide: id}})
     .then(function(session) {
       res.json(session);
     }, function(err) {
@@ -32,7 +33,8 @@ module.exports = {
   },
 
   getAllUsers: function(req, res, next) {
-    Session.find({where: {id: req.params.sessionId}})
+    var sessionId = req.params.sessionId;
+    Session.find({where: {id: sessionId}})
     .then(function(session) {
       // use Sequelize method provided by belongsToMany relationship
       return session.getUsers();
@@ -50,11 +52,9 @@ module.exports = {
   // },
 
   addUser: function(req, res, next) {
-    var userId = parseInt(req.body.userId);
-    var sessionId = parseInt(req.body.sessionId);
-    User.find({where: {id: userId}})
+    User.find({where: {id: req.body.userId}})
     .then(function(user) {
-      Session.find({where: {id: sessionId}})
+      Session.find({where: {id: req.body.sessionId}})
       .then(function(session) {
         return {
           user: user,

--- a/server/sessions_users/sessions_users.js
+++ b/server/sessions_users/sessions_users.js
@@ -1,47 +1,47 @@
-var db = require( '../config/db' );
-var helpers = require( '../config/helpers' );
-var Sequelize = require( 'sequelize' );
-var User = require( '../users/users' );
-var Session = require( '../sessions/sessions' );
+// var db = require( '../config/db' );
+// var helpers = require( '../config/helpers' );
+// var Sequelize = require( 'sequelize' );
+// var User = require( '../users/users' );
+// var Session = require( '../sessions/sessions' );
 
-var Session_User = db.define( 'sessions_users', {
-	user_id: {
-    type: Sequelize.INTEGER,
-    unique: 'session_user_idx'
-  },
-	session_id: {
-    type: Sequelize.INTEGER,
-    unique: 'session_user_idx'
-  }
-} );
+// var Session_User = db.define( 'sessions_users', {
+// 	user_id: {
+//     type: Sequelize.INTEGER,
+//     unique: 'session_user_idx'
+//   },
+// 	session_id: {
+//     type: Sequelize.INTEGER,
+//     unique: 'session_user_idx'
+//   }
+// } );
 
-Session_User.sync().then( function(){
-  console.log("sessions_users table created");
-} )
-.catch( function( err ){
-  console.error(err);
-} );
+// Session_User.sync().then( function(){
+//   console.log("sessions_users table created");
+// } )
+// .catch( function( err ){
+//   console.error(err);
+// } );
 
-Session_User.belongsTo( User, {foreignKey: 'user_id'} );
-Session_User.belongsTo( Session, {foreignKey: 'session_id'} );
+// Session_User.belongsTo( User, {foreignKey: 'user_id'} );
+// Session_User.belongsTo( Session, {foreignKey: 'session_id'} );
 
-Session_User.getSessionUserBySessionIdAndUserId = function( sessionID, userID ) {
-  console.log('searching in ....getSessionUserBySessionIdAndUserId......');
-  return Session_User.findOne({where: {session_id: sessionID, user_id: userID} })
-    .catch( function( err ) {
-      helpers.errorLogger( err );
-    });
-};
+// Session_User.getSessionUserBySessionIdAndUserId = function( sessionID, userID ) {
+//   console.log('searching in ....getSessionUserBySessionIdAndUserId......');
+//   return Session_User.findOne({where: {session_id: sessionID, user_id: userID} })
+//     .catch( function( err ) {
+//       helpers.errorLogger( err );
+//     });
+// };
 
-Session_User.countUsersInOneSession = function( sessionID ) {
-  return Session_User.count( { where: { session_id: sessionID } } )
-  .then( function( result ) {
-    console.log( 'Count', sessionID, result );
-    return result;
-  })
-  .catch( function( err ) {
-    helpers.errorLogger( err );
-  });
-};
+// Session_User.countUsersInOneSession = function( sessionID ) {
+//   return Session_User.count( { where: { session_id: sessionID } } )
+//   .then( function( result ) {
+//     console.log( 'Count', sessionID, result );
+//     return result;
+//   })
+//   .catch( function( err ) {
+//     helpers.errorLogger( err );
+//   });
+// };
 
-module.exports = Session_User; 
+// module.exports = Session_User; 

--- a/server/votes/votes.js
+++ b/server/votes/votes.js
@@ -2,7 +2,7 @@ var Sequelize = require( 'sequelize' );
 
 var db = require( '../config/db' );
 var helpers = require( '../config/helpers' );
-var Session_User = require( '../sessions_users/sessions_users' );
+// var Session_User = require( '../sessions_users/sessions_users' );
 
 
 var Vote = db.define( 'votes', {
@@ -24,7 +24,7 @@ Vote.sync().then( function() {
   console.error( err );
 } );
 
-Vote.belongsTo( Session_User, {foreignKey: 'session_user_id'} );
+// Vote.belongsTo( Session_User, {foreignKey: 'session_user_id'} );
 
 Vote.addVote = function( sessionUser, movie, vote ) {
   return Vote.create( { session_user_id: sessionUser, movie_id: movie, vote: vote } )


### PR DESCRIPTION
Deprecate sessions_users table/model/controller
Use Sequelize belongsToMany relationship to create many-to-many relationship between user and sessions
Refactor server side API endpoints to use user and session id instead of name
