### PR TITLE
Implement jwt tokens, use RESTful session/user routes

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -52,29 +52,29 @@ var app = angular.module( 'dinnerDaddy', [
       redirectTo: '/signin'
     })
 
-    // $httpProvider.interceptors.push('AttachTokens');
+    $httpProvider.interceptors.push('AttachTokens');
 
 })
 
-// .factory('AttachTokens', function ($window) {
-//   var attach = {
-//     request: function (object) {
-//       var jwt = $window.localStorage.getItem('com.dinnerDaddy');
-//       if (jwt) {
-//         object.headers['x-access-token'] = jwt;
-//       }
-//       object.headers['Allow-Control-Allow-Origin'] = '*';
-//       return object;
-//     }
-//   };
-//   return attach;
-// })
+.factory('AttachTokens', function ($window) {
+  var attach = {
+    request: function (object) {
+      var jwt = $window.localStorage.getItem('com.dinnerDaddy');
+      if (jwt) {
+        object.headers['x-access-token'] = jwt;
+      }
+      object.headers['Allow-Control-Allow-Origin'] = '*';
+      return object;
+    }
+  };
+  return attach;
+})
 
-// .run(function ($rootScope, $location, Auth) {
-//   $rootScope.$on('$routeChangeStart', function (evt, next, current) {
-//     if (next.$$route && next.$$route.authenticate && !Auth.isAuth()) {
-//       $location.path('/signin');
-//     }
-//   });
-// });
+.run(function ($rootScope, $location, Auth) {
+  $rootScope.$on('$routeChangeStart', function (evt, next, current) {
+    if (next.$$route && next.$$route.authenticate && !Auth.isAuth()) {
+      $location.path('/signin');
+    }
+  });
+});
 

--- a/client/app/auth/auth.js
+++ b/client/app/auth/auth.js
@@ -28,11 +28,14 @@ angular.module( 'dinnerDaddy.auth', [] )
       params: {
         fbId: fbId
       }
-    });
+    })
+    .then(function(res) {
+      return res.data;
+    })
   };
 
   var isAuth = function() {
-    return !!$window.localStorage.getItem('com.dinnerDaddy');
+    return !!$cookies.get('fbId');
   };
 
   var signout = function() {

--- a/client/app/auth/auth.js
+++ b/client/app/auth/auth.js
@@ -21,8 +21,18 @@ angular.module( 'dinnerDaddy.auth', [] )
 })
 
 .factory( 'Auth', function($http, $cookies, $location, $window) {
+  var getUserToken = function(fbId) {
+    return $http({
+      method: 'GET',
+      url: '/api/users',
+      params: {
+        fbId: fbId
+      }
+    });
+  };
+
   var isAuth = function() {
-    return ($cookies.get('fbId') !== undefined);
+    return !!$window.localStorage.getItem('com.dinnerDaddy');
   };
 
   var signout = function() {
@@ -30,9 +40,13 @@ angular.module( 'dinnerDaddy.auth', [] )
     $cookies.remove("name");
     $cookies.remove("picture");
     $cookies.remove("fbId");
+
+    //clear localStorage
+    $window.localStorage.removeItem('com.dinnerDaddy');
   };
 
   return {
+    getUserToken: getUserToken,
     isAuth: isAuth,
     signout: signout
   };

--- a/client/app/auth/auth.js
+++ b/client/app/auth/auth.js
@@ -46,6 +46,7 @@ angular.module( 'dinnerDaddy.auth', [] )
 
     //clear localStorage
     $window.localStorage.removeItem('com.dinnerDaddy');
+    $window.localStorage.removeItem('sessionName');
   };
 
   return {

--- a/client/app/lobby/lobby.js
+++ b/client/app/lobby/lobby.js
@@ -1,22 +1,22 @@
 angular.module( 'dinnerDaddy.lobby', [] )
 
-.controller( 'LobbyController', function( $scope, Session, Lobby, Socket, $location, Auth ) {
-  $scope.session = {};
+.controller('LobbyController', function($scope, $rootScope, Session, Lobby, Socket, $location, Auth) {
+  // $scope.session = {};
+  // $scope.username = Auth.getUserName();
+  $scope.users = [];
 
-  Session.getSession()
-  .then( function( session ) {
+  // Session.getSession()
+  // .then( function( session ) {
 
-    $scope.session = session;
+  //   $scope.session = session;
     
-    Lobby.getUsersInOneSession( $scope.session.sessionName )
-    .then( function( users ){
-      $scope.users = users;
-    } );
-
+  Lobby.getUsersInOneSession($rootScope.currentSession.id)
+  .then(function(users){
+    $scope.users = users;
   });
 
-  $scope.username = Auth.getUserName();
-  $scope.users = [];
+  // });
+
 
 
   //this function is listening to any newUser event and recieves/appends the new user
@@ -33,3 +33,22 @@ angular.module( 'dinnerDaddy.lobby', [] )
   } );
 
 } )
+
+.factory('Lobby', function($http) {
+  return {
+    getUsersInOneSession: function(sessionId) {
+      return $http({
+        method:'GET',
+        url: '/api/sessions/'+ sessionId + '/users/',
+        params: {
+          sessionId: sessionId
+        }})
+      .then(function(res) {
+        return res.data;
+      })
+      .catch(function(err) {
+        console.error(err);
+      });
+    }
+  }
+});

--- a/client/app/sessions/joinsessions.html
+++ b/client/app/sessions/joinsessions.html
@@ -30,6 +30,6 @@ or the user can join a group that their friend has already created -->
   <hr>
 </div>
 <div class="join-group-cnt block-center" ng-repeat="session in sessions track by $index">
-  <button class="col-xs-12 btn-mobile visible-xs visible-sm" ng-click="joinSession( session.sessionName )">Join <span class="bold">{{ session.sessionName }}</span></button>
-  <button class="col-xs-12 btn-laptop hidden-xs hidden-sm" ng-click="joinSession( session.sessionName )">Join <span class="bold">{{ session.sessionName }}</span></button>
+  <button class="col-xs-12 btn-mobile visible-xs visible-sm" ng-click="joinSession($index)">Join <span class="bold">{{ session.sessionName }}</span></button>
+  <button class="col-xs-12 btn-laptop hidden-xs hidden-sm" ng-click="joinSession($index)">Join <span class="bold">{{ session.sessionName }}</span></button>
 </div>

--- a/client/app/sessions/sessions.js
+++ b/client/app/sessions/sessions.js
@@ -6,10 +6,21 @@ angular.module('dinnerDaddy.sessions', [])
 
   $scope.sessionName = '';
 
+  Auth.getUserToken($cookies.get('fbId'))
+  .then(function(token) {
+    $window.localStorage.setItem('com.dinnerDaddy', token);
+  })
+  .catch(function(err) {
+    console.error(err);
+  });
+
   $scope.fetchSessions = function() {
-    Session.fetchSessions($scope.username)
+    Session.fetchSessions()
     .then(function(sessions) {
       $scope.sessions = sessions;
+    })
+    .catch(function(err) {
+      console.error(err);
     });
   };
 
@@ -77,30 +88,23 @@ angular.module('dinnerDaddy.sessions', [])
       });
     };
 
-    var fetchSessions = function(username) {
+    var fetchSessions = function() {
       return $http({
         method:'GET',
-        url: '/api/sessions',
-        params: {
-          username: username
-        }
+        url: '/api/sessions'
       })
       .then(function(res) {
         return res.data;
-      })
-      .catch(function(err) {
-        console.error(err);
-      }); 
+      });
     };
     // change to user id not username, call it userId, same with session
     // SHOULD BE A NUMBER
-    var joinSession = function(username, sessionName) {
+    var joinSession = function(sessionId) {
       return $http({
         method: 'POST',
         url: '/api/sessions/users',
         data: {
-          sessionName: sessionName,
-          username: username
+          sessionId: sessionId
         }
       });
     };

--- a/client/app/sessions/sessions.js
+++ b/client/app/sessions/sessions.js
@@ -1,6 +1,6 @@
 angular.module('dinnerDaddy.sessions', [])
 
-.controller('SessionsController', function ($scope, $cookies, Session, Auth, Socket) {
+.controller('SessionsController', function ($scope, $cookies, $window, Session, Auth, Socket) {
   $scope.username = $cookies.get('name');
   $scope.sessions = [];
 
@@ -97,8 +97,7 @@ angular.module('dinnerDaddy.sessions', [])
         return res.data;
       });
     };
-    // change to user id not username, call it userId, same with session
-    // SHOULD BE A NUMBER
+
     var joinSession = function(sessionId) {
       return $http({
         method: 'POST',

--- a/client/app/sessions/sessions.js
+++ b/client/app/sessions/sessions.js
@@ -1,6 +1,6 @@
 angular.module('dinnerDaddy.sessions', [])
 
-.controller('SessionsController', function ($scope, $rootScope, $cookies, $window, Session, Auth, Socket) {
+.controller('SessionsController', function ($scope, $rootScope, $cookies, $window, $location, Session, Auth, Socket) {
   $scope.username = $cookies.get('name');
   $rootScope.currentSession;
   $scope.sessions = [];
@@ -28,19 +28,21 @@ angular.module('dinnerDaddy.sessions', [])
   // UNCOMMENT THIS WHEN IT WORKS: $scope.fetchSessions();
 
   //this function listens to a event emitted by server.js-'new session' and recieves and appends the new session
-  Socket.on('newSession', function(data) {
-    $scope.sessions.push(data);
-  });
+  // COMMENTING THIS OUT FOR NOW AND ADDING in $scope.createSession
+  // Socket.on('newSession', function(data) {
+  //   $scope.sessions.push(data);
+  // });
 
   $scope.setSession = Session.setSession;
 
   $scope.createSession = function() {
     Session.createSession($scope.sessionName, $scope.sessionLocation)
-    .then(function() {
+    .then(function(session) {
       console.log('created session');
       $rootScope.currentSession = session;
-      Socket.emit('session', {sessionName: $scope.sessionName});
-      $scope.joinSession($scope.sessionName);
+      Socket.emit('session', {sessionName: session.sessionName});
+      $scope.sessions.push(session);
+      $scope.joinSession($scope.sessions.length - 1);
     })
     .catch(function(error) {
       console.error(error);
@@ -89,7 +91,10 @@ angular.module('dinnerDaddy.sessions', [])
           sessionLocation: sessionLocation
 
         }
-      });
+      })
+      .then(function(res) {
+        return res.data;
+      })
     };
 
     var fetchSessions = function() {

--- a/client/app/sessions/sessions.js
+++ b/client/app/sessions/sessions.js
@@ -110,10 +110,7 @@ angular.module('dinnerDaddy.sessions', [])
     var joinSession = function(sessionId) {
       return $http({
         method: 'POST',
-        url: '/api/sessions/users',
-        data: {
-          sessionId: sessionId
-        }
+        url: '/api/sessions/' + sessionId + '/users'
       });
     };
 

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -72,9 +72,9 @@ module.exports = function ( app, express ) {
 
   /* SESSIONS_USERS */
   app.use('/api/sessions/users', helpers.decode);
-  app.get('/api/sessions/users', sessionsController.getAllUsers);
+  app.get('/api/sessions/:sessionId/users', sessionsController.getAllUsers);
   // app.get('/api/sessions/:session_id/:user_id', sessionsController.getOneUser);
-  app.post('/api/sessions/users', sessionsController.addUser);
+  app.post('/api/sessions/:sessionId/users', sessionsController.addUser);
 
   /* MATCHING */
   // This endpoint answers the question, 'For session <id>, do we currently have a match on movie <id>?'

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -39,36 +39,41 @@ module.exports = function ( app, express ) {
     res.redirect('/#/signin');
   });
 
-
-
+  /* USER AUTH */
+  app.get('/api/users', usersController.getUserToken);
 
   /* GENRES */
+  app.use('/api/genres', helpers.decode);
   app.get('/api/genres', genresController.getAllGenres );
   app.get('/api/genres/:genre', genresController.getGenre );
 
   /* MOVIES */
+  app.use('/api/movies', helpers.decode);
   app.get('/api/movies', moviesController.getAllMovies );
   app.get('/api/movies/package/:number', moviesController.getMoviePackage );
   app.get('/api/movies/:movie_id', moviesController.getMovie );
 
   /* PREFS */
+  app.use('/api/prefs', helpers.decode);
   app.get('/api/prefs', prefsController.getPrefs );
   app.post('/api/prefs', prefsController.addPrefs );
 
   /* SESSIONS */
-  app.get('/api/sessions', sessionsController.getAllSessions );
-  app.post('/api/sessions', sessionsController.addSession );
+  app.use('/api/sessions', helpers.decode);
+  app.get('/api/sessions', sessionsController.getAllSessions);
+  app.get('/api/sessions/:id', sessionsController.getSession);
+  app.post('/api/sessions', sessionsController.addSession);
 
   /* VOTES */
+  app.use('/api/votes', helpers.decode);
   app.get('/api/votes', votesController.getAllVotes );
   app.get('/api/votes/:session_id/:movie_id', votesController.getSessMovieVotes ); // get votes for a particular session and movie
   app.post('/api/votes', votesController.addVote );
 
   /* SESSIONS_USERS */
-  app.get('/api/sessions/users/:sessionId', sessionsController.getAllUsers);
-  app.get('/api/sessions/:id', sessionsController.getSession);
+  app.get('/api/sessions/:sessionId/users', sessionsController.getAllUsers);
   // app.get('/api/sessions/:session_id/:user_id', sessionsController.getOneUser);
-  app.post('/api/sessions/users', sessionsController.addUser);
+  app.post('/api/sessions/:sessionId/users', sessionsController.addUser);
 
   /* MATCHING */
   // This endpoint answers the question, 'For session <id>, do we currently have a match on movie <id>?'
@@ -79,7 +84,7 @@ module.exports = function ( app, express ) {
 
   // If a request is sent somewhere other than the routes above,
   // send it through our custom error handler
-  app.use( helpers.errorLogger );
-  app.use( helpers.errorHandler );
+  app.use(helpers.errorLogger);
+  app.use(helpers.errorHandler);
 
 };

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -71,9 +71,10 @@ module.exports = function ( app, express ) {
   app.post('/api/votes', votesController.addVote );
 
   /* SESSIONS_USERS */
-  app.get('/api/sessions/:sessionId/users', sessionsController.getAllUsers);
+  app.use('/api/sessions/users', helpers.decode);
+  app.get('/api/sessions/users', sessionsController.getAllUsers);
   // app.get('/api/sessions/:session_id/:user_id', sessionsController.getOneUser);
-  app.post('/api/sessions/:sessionId/users', sessionsController.addUser);
+  app.post('/api/sessions/users', sessionsController.addUser);
 
   /* MATCHING */
   // This endpoint answers the question, 'For session <id>, do we currently have a match on movie <id>?'

--- a/server/sessions/sessionsController.js
+++ b/server/sessions/sessionsController.js
@@ -56,7 +56,7 @@ module.exports = {
   },
 
   addUser: function(req, res, next) {
-    var sessionId = parseInt(req.body.sessionId);
+    var sessionId = parseInt(req.params.sessionId);
     User.find({where: {id: req.user.id}})
     .then(function(user) {
       Session.find({where: {id: sessionId}})

--- a/server/sessions/sessionsController.js
+++ b/server/sessions/sessionsController.js
@@ -5,7 +5,7 @@ var User = require('../users/users');
 module.exports = {
 
   getAllSessions: function(req, res, next) {
-    User.find({where: {id: req.query.userId}})
+    User.find({where: {id: req.user.id}})
     .then(function(user) {
       return user.getSessions();
     })
@@ -32,7 +32,7 @@ module.exports = {
 
   getSession: function(req, res, next) {
     var id = parseInt(req.params.id);
-    Session.findOne({where: {ide: id}})
+    Session.findOne({where: {id: id}})
     .then(function(session) {
       res.json(session);
     }, function(err) {
@@ -56,9 +56,9 @@ module.exports = {
   },
 
   addUser: function(req, res, next) {
-    User.find({where: {id: req.body.userId}})
+    User.find({where: {id: req.user.id}})
     .then(function(user) {
-      Session.find({where: {id: req.body.sessionId}})
+      Session.find({where: {id: req.params.sessionId}})
       .then(function(session) {
         return {
           user: user,

--- a/server/sessions/sessionsController.js
+++ b/server/sessions/sessionsController.js
@@ -41,7 +41,7 @@ module.exports = {
   },
 
   getAllUsers: function(req, res, next) {
-    var sessionId = req.params.sessionId;
+    var sessionId = parseInt(req.params.sessionId);
     Session.find({where: {id: sessionId}})
     .then(function(session) {
       // use Sequelize method provided by belongsToMany relationship

--- a/server/sessions/sessionsController.js
+++ b/server/sessions/sessionsController.js
@@ -5,10 +5,16 @@ var User = require('../users/users');
 module.exports = {
 
   getAllSessions: function(req, res, next) {
-    Session.findAll()
-    .then(function(sessions) {
-      res.send(sessions);
+    User.find({where: {id: req.query.userId}})
+    .then(function(user) {
+      return user.getSessions();
     })
+    .then(function(sessions) {
+      res.json(sessions);
+    })
+    .catch(function(err) {
+      helpers.errorHandler(err, req, res, next);
+    });
   },
 
   addSession: function(req, res, next) {
@@ -48,10 +54,6 @@ module.exports = {
       console.error(err);
     });
   },
-
-  // getOneUser: function(req, res, next) {
-  //   console.log('query', req.query);
-  // },
 
   addUser: function(req, res, next) {
     User.find({where: {id: req.body.userId}})

--- a/server/sessions/sessionsController.js
+++ b/server/sessions/sessionsController.js
@@ -56,9 +56,10 @@ module.exports = {
   },
 
   addUser: function(req, res, next) {
+    var sessionId = parseInt(req.body.sessionId);
     User.find({where: {id: req.user.id}})
     .then(function(user) {
-      Session.find({where: {id: req.params.sessionId}})
+      Session.find({where: {id: sessionId}})
       .then(function(session) {
         return {
           user: user,
@@ -70,6 +71,7 @@ module.exports = {
         var user = data.user;
         // use Sequelize method provided by belongsToMany relationship
         session.addUser(user);
+        res.statusCode = 201;
         res.json(user);
       })
     })

--- a/server/users/usersController.js
+++ b/server/users/usersController.js
@@ -1,8 +1,20 @@
 var User = require( './users' );
 var Friendship = require('../friendships/friendshipController');
 var Promise = require('bluebird');
+var jwt =require('jwt-simple')
 
 module.exports = {
+
+  getUserToken: function(req, res) {
+    User.find({where: {fb_id: req.fbId}})
+    .then(function(user) {
+      var token = jwt.encode(user, 'secret');
+      res.json(token);
+    })
+    .catch(function(err) {
+      console.error(err);
+    })
+  },
   
   getFriends: function (profile) {
 

--- a/server/users/usersController.js
+++ b/server/users/usersController.js
@@ -6,7 +6,7 @@ var jwt =require('jwt-simple')
 module.exports = {
 
   getUserToken: function(req, res) {
-    User.find({where: {fb_id: req.fbId}})
+    User.find({where: {fb_id: req.query.fbId}})
     .then(function(user) {
       var token = jwt.encode(user, 'secret');
       res.json(token);


### PR DESCRIPTION
Use jwt tokens for authentication
Add user to every request using helpers.decode in helpers.js (no longer sending username or user id and finding user with every request)

Token is created and sent to client on page load of '/#/sessions'. This means we're still checking authorization on the client side with cookies (checking fbId).

Use session id in RESTful routes to add user to session and to get all users in a session.
